### PR TITLE
fix: line break does not show

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ npm install
 3. Create a `.env` file in the root directory and add the URL to the database:
 ```bash
 // File: .env.local
-DATABASE_URL="postgres://..."
-DATABASE_URL_DEV="postgres://..."
+DATABASE_URL="postgresql://..."
+DATABASE_URL_DEV="postgresql://..."
 ```
 4. Run the server
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-vale",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-vale",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-vale",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/ViewCards/index.tsx
+++ b/src/components/ViewCards/index.tsx
@@ -35,7 +35,6 @@ export default function ViewCards() {
         if (resj.success) {
           setData(resj.data);
           setTotalPage(Math.ceil(resj.totalCount / PAGE_LIMIT));
-          console.log(totalPage);
         } else {
           console.error("Error fetching data:", resj.error);
         }
@@ -92,7 +91,15 @@ export default function ViewCards() {
               暱稱：{item.name}
             </CardDescription>
           </CardHeader>
-          <CardContent className="text-lg mb-4">{item.content}</CardContent>
+          <CardContent className="text-lg mb-4">
+            {item.content.split("\n").map((line: string, index: number) => {
+              return (
+                <p key={index}>
+                  {line}
+                </p>
+              );
+            })}
+          </CardContent>
         </Card>
       ))}
       <Pagination>

--- a/src/components/ViewCards/index.tsx
+++ b/src/components/ViewCards/index.tsx
@@ -25,7 +25,7 @@ export default function ViewCards() {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [data, setData] = useState([]);
-  const [totalPage, setTotalData] = useState(0);
+  const [totalPage, setTotalPage] = useState(0);
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -34,7 +34,8 @@ export default function ViewCards() {
       .then((resj) => {
         if (resj.success) {
           setData(resj.data);
-          setTotalData(Math.ceil(resj.totalCount / PAGE_LIMIT));
+          setTotalPage(Math.ceil(resj.totalCount / PAGE_LIMIT));
+          console.log(totalPage);
         } else {
           console.error("Error fetching data:", resj.error);
         }
@@ -97,13 +98,13 @@ export default function ViewCards() {
       <Pagination>
         <PaginationContent>
           <PaginationItem>
-            <PaginationPrevious href="#" aria-disabled={currentPage === 1} isActive={currentPage !== 1} onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}/>
+            <PaginationPrevious className={currentPage === 1 ? 'text-gray-500' : ''} href="#" aria-disabled={currentPage === 1} isActive={currentPage !== 1} onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}/>
           </PaginationItem>
           <PaginationItem>
             <PaginationLink>{currentPage}</PaginationLink>
           </PaginationItem>
           <PaginationItem>
-            <PaginationNext href="#" aria-disabled={currentPage === totalPage} isActive={currentPage !== totalPage} onClick={() => setCurrentPage(Math.min(currentPage + 1, totalPage))}/>
+            <PaginationNext className={currentPage === totalPage ? 'text-gray-500' : ''} href="#" aria-disabled={currentPage === totalPage} isActive={currentPage !== totalPage} onClick={() => setCurrentPage(Math.min(currentPage + 1, totalPage))}/>
           </PaginationItem>
         </PaginationContent>
       </Pagination>


### PR DESCRIPTION
This pull request fixes issue #6, where line breaks does not show.

Previously, the content of each data is shown like this:
```tsx
<CardContent className="text-lg mb-4">
  {item.content}
</CardContent>
```
Which is why line breaks does not show, as neither `<br>` is presented, nor is it different HTML elements.

To (re)show line breaks, the following code is implemented:
```tsx
<CardContent className="text-lg mb-4">
  {item.content.split("\n").map((line: string, index: number) => {
    return (
      <p key={index}>
        {line}
      </p>
    );
  })}
</CardContent>
```
It essentially put two lines with line breaks in the middle to different `<p>`'s so that that the two line breaks "appear" to be rendered.