### PR TITLE
refractor: change database schema

### DIFF
--- a/src/app/actions/SubmitData.ts
+++ b/src/app/actions/SubmitData.ts
@@ -13,6 +13,7 @@ const FormDataSchema = z.object({
     return arg;
   }, z.string().max(64)),
   content: z.string().max(2048),
+  category: z.enum(["silent_comments", "starlight_comments"]),
 });
 
 export type SubmitState = {
@@ -29,13 +30,7 @@ export async function submitData(_: SubmitState, formData: FormData) {
   if (!parsedData.success) {
     throw parsedData.error;
   }
-  const { name, content } = parsedData.data;
-
-  const category = formData.get("category");
-  
-  if (category !== "silent_comments" && category !== "starlight_comments") {
-    throw new Error("Invalid category");
-  }
+  const { name, content, category } = parsedData.data;
 
   const currentDate = new Date().toISOString();
   const status = "pending";

--- a/src/app/actions/SubmitData.ts
+++ b/src/app/actions/SubmitData.ts
@@ -33,7 +33,7 @@ export async function submitData(_: SubmitState, formData: FormData) {
 
   const category = formData.get("category");
   
-  if (category !== "slient_comments" && category !== "starlight_comments") {
+  if (category !== "silent_comments" && category !== "starlight_comments") {
     throw new Error("Invalid category");
   }
 
@@ -45,9 +45,9 @@ export async function submitData(_: SubmitState, formData: FormData) {
       ? neon(`${process.env.DATABASE_URL}`)
       : neon(`${process.env.DATABASE_URL_DEV}`);
   try {
-    if (category === "slient_comments") {
+    if (category === "silent_comments") {
       await sql`
-        INSERT INTO slient_comments (name, content, created_at, status) 
+        INSERT INTO silent_comments (name, content, created_at, status) 
         VALUES (${name}, ${content}, ${currentDate}, ${status});
       `;
     }

--- a/src/app/actions/SubmitData.ts
+++ b/src/app/actions/SubmitData.ts
@@ -32,7 +32,8 @@ export async function submitData(_: SubmitState, formData: FormData) {
   const { name, content } = parsedData.data;
 
   const category = formData.get("category");
-  if (category !== "neg" && category !== "pos") {
+  
+  if (category !== "slient_comments" && category !== "starlight_comments") {
     throw new Error("Invalid category");
   }
 
@@ -44,10 +45,18 @@ export async function submitData(_: SubmitState, formData: FormData) {
       ? neon(`${process.env.DATABASE_URL}`)
       : neon(`${process.env.DATABASE_URL_DEV}`);
   try {
-    await sql`
-      INSERT INTO comments (name, content, created_at, status, positivity) 
-      VALUES (${name}, ${content}, ${currentDate}, ${status}, ${category});
-    `;
+    if (category === "slient_comments") {
+      await sql`
+        INSERT INTO slient_comments (name, content, created_at, status) 
+        VALUES (${name}, ${content}, ${currentDate}, ${status});
+      `;
+    }
+    if (category === "starlight_comments") {
+      await sql`
+        INSERT INTO starlight_comments (name, content, created_at, status) 
+        VALUES (${name}, ${content}, ${currentDate}, ${status});
+      `;
+    }
     return {
       success: true,
       error: null,

--- a/src/app/api/fetchdatan/route.ts
+++ b/src/app/api/fetchdatan/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       neon(`${process.env.DATABASE_URL}`) :
       neon(`${process.env.DATABASE_URL_DEV}`);
 
-  const MAX_PAGE_RESULT = await sql`SELECT COUNT(*) FROM comments WHERE status = 'approved' AND positivity = 'neg';`;
+  const MAX_PAGE_RESULT = await sql`SELECT COUNT(*) FROM slient_comments WHERE status = 'approved';`;
   const MAX_PAGE = MAX_PAGE_RESULT as { count: number }[];
 
   const totalPages = Math.ceil(MAX_PAGE[0].count / PAGE_SIZE);
@@ -26,8 +26,8 @@ export async function GET(request: NextRequest) {
     pageNumber = 1;
   }
   const offset = (pageNumber - 1) * PAGE_SIZE;
-  const data = await sql`SELECT * FROM comments
-    WHERE status = 'approved' AND positivity = 'neg'
+  const data = await sql`SELECT * FROM slient_comments
+    WHERE status = 'approved'
     ORDER BY created_at DESC
     LIMIT ${PAGE_SIZE}
     OFFSET ${offset};`;

--- a/src/app/api/fetchdatan/route.ts
+++ b/src/app/api/fetchdatan/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       neon(`${process.env.DATABASE_URL}`) :
       neon(`${process.env.DATABASE_URL_DEV}`);
 
-  const MAX_PAGE_RESULT = await sql`SELECT COUNT(*) FROM slient_comments WHERE status = 'approved';`;
+  const MAX_PAGE_RESULT = await sql`SELECT COUNT(*) FROM silent_comments WHERE status = 'approved';`;
   const MAX_PAGE = MAX_PAGE_RESULT as { count: number }[];
 
   const totalPages = Math.ceil(MAX_PAGE[0].count / PAGE_SIZE);
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
     pageNumber = 1;
   }
   const offset = (pageNumber - 1) * PAGE_SIZE;
-  const data = await sql`SELECT * FROM slient_comments
+  const data = await sql`SELECT * FROM silent_comments
     WHERE status = 'approved'
     ORDER BY created_at DESC
     LIMIT ${PAGE_SIZE}

--- a/src/app/api/fetchdatap/route.ts
+++ b/src/app/api/fetchdatap/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       neon(`${process.env.DATABASE_URL}`) :
       neon(`${process.env.DATABASE_URL_DEV}`);
 
-  const MAX_PAGE_RESULT = await sql`SELECT COUNT(*) FROM comments WHERE status = 'approved' AND positivity = 'pos';`;
+  const MAX_PAGE_RESULT = await sql`SELECT COUNT(*) FROM starlight_comments WHERE status = 'approved';`;
   const MAX_PAGE = MAX_PAGE_RESULT as { count: number }[];
 
   const totalPages = Math.ceil(MAX_PAGE[0].count / PAGE_SIZE);
@@ -26,8 +26,8 @@ export async function GET(request: NextRequest) {
     pageNumber = 1;
   }
   const offset = (pageNumber - 1) * PAGE_SIZE;
-  const data = await sql`SELECT * FROM comments
-    WHERE status = 'approved' AND positivity = 'pos'
+  const data = await sql`SELECT * FROM starlight_comments
+    WHERE status = 'approved'
     ORDER BY created_at DESC
     LIMIT ${PAGE_SIZE}
     OFFSET ${offset};`;

--- a/src/components/CommentForm/index.tsx
+++ b/src/components/CommentForm/index.tsx
@@ -79,7 +79,7 @@ export default function CommentForm() {
           <Button type="submit" className="w-full mt-4 cursor-pointer" disabled={isPending}>
             {isPending ? '請稍後...' : '發送'}
           </Button>
-          {(state.error) && <div className="text-red-500 mt-2">發送失敗，請稍後再試。{state.error.toString()}</div>}
+          {(state.error) && <div className="text-red-500 mt-2">發送失敗，請稍後再試。</div>}
         </Form>}
       {/* After receiving success response */}
       {(state.success) &&

--- a/src/components/CommentForm/index.tsx
+++ b/src/components/CommentForm/index.tsx
@@ -41,15 +41,15 @@ export default function CommentForm() {
             <span className="text-lg font-semibold mb-2">類別</span>
             <div className="pt-2 space-y-2">
               <div>
-                <input type="radio" name="category" value="neg" id="neg" defaultChecked />
-                <label className="ml-2 text-md" htmlFor="neg">
+                <input type="radio" name="category" value="slient_comments" id="slient_comments" defaultChecked />
+                <label className="ml-2 text-md" htmlFor="slient_comments">
                   <span className="text-md">靜谷之聲</span> <br />
                   <span className="text-sm text-gray-400">向其他旅人分享你的故事、情緒。</span>
                 </label>
               </div>
               <div>
-                <input type="radio" name="category" value="pos" id="pos" />
-                <label className="ml-2 text-md" htmlFor="pos">
+                <input type="radio" name="category" value="starlight_comments" id="starlight_comments" />
+                <label className="ml-2 text-md" htmlFor="starlight_comments">
                   <span className="text-md">星光之聲</span> <br />
                   <span className="text-sm text-gray-400">用溫暖、鼓勵的言語點亮山谷的夜空。</span>
                 </label>
@@ -79,7 +79,7 @@ export default function CommentForm() {
           <Button type="submit" className="w-full mt-4 cursor-pointer" disabled={isPending}>
             {isPending ? '請稍後...' : '發送'}
           </Button>
-          {(state.error) && <div className="text-red-500 mt-2">發送失敗，請稍後再試。</div>}
+          {(state.error) && <div className="text-red-500 mt-2">發送失敗，請稍後再試。{state.error.toString()}</div>}
         </Form>}
       {/* After receiving success response */}
       {(state.success) &&

--- a/src/components/CommentForm/index.tsx
+++ b/src/components/CommentForm/index.tsx
@@ -41,8 +41,8 @@ export default function CommentForm() {
             <span className="text-lg font-semibold mb-2">類別</span>
             <div className="pt-2 space-y-2">
               <div>
-                <input type="radio" name="category" value="slient_comments" id="slient_comments" defaultChecked />
-                <label className="ml-2 text-md" htmlFor="slient_comments">
+                <input type="radio" name="category" value="silent_comments" id="silent_comments" defaultChecked />
+                <label className="ml-2 text-md" htmlFor="silent_comments">
                   <span className="text-md">靜谷之聲</span> <br />
                   <span className="text-sm text-gray-400">向其他旅人分享你的故事、情緒。</span>
                 </label>


### PR DESCRIPTION
The original database put all `slient_comments` and `starlight_comments` into a single table, which accidentally labels comments as "positive" and "negative" (which isn't ideal) and limits scalability. This PR separates them into two tables, potentially increasing performance, and it also eliminates labelling of comments in code.