### PR TITLE
test: populate test cases with functionality tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "dotenv": "^16.5.0",
         "eslint": "^9",
         "eslint-config-next": "15.2.4",
         "tailwindcss": "^4",
@@ -2542,6 +2543,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^16.5.0",
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
     "tailwindcss": "^4",

--- a/src/components/CommentForm/index.tsx
+++ b/src/components/CommentForm/index.tsx
@@ -31,6 +31,7 @@ export default function CommentForm() {
             <input
               name="name"
               type="text"
+              data-testid="name"
               className="border border-gray-300 rounded-md p-2"
               placeholder="佚名"
               maxLength={64}
@@ -41,14 +42,14 @@ export default function CommentForm() {
             <span className="text-lg font-semibold mb-2">類別</span>
             <div className="pt-2 space-y-2">
               <div>
-                <input type="radio" name="category" value="silent_comments" id="silent_comments" defaultChecked />
+                <input type="radio" name="category" value="silent_comments" id="silent_comments" data-testid="cat-silent" defaultChecked />
                 <label className="ml-2 text-md" htmlFor="silent_comments">
                   <span className="text-md">靜谷之聲</span> <br />
                   <span className="text-sm text-gray-400">向其他旅人分享你的故事、情緒。</span>
                 </label>
               </div>
               <div>
-                <input type="radio" name="category" value="starlight_comments" id="starlight_comments" />
+                <input type="radio" name="category" value="starlight_comments" id="starlight_comments" data-testid="cat-starlight" />
                 <label className="ml-2 text-md" htmlFor="starlight_comments">
                   <span className="text-md">星光之聲</span> <br />
                   <span className="text-sm text-gray-400">用溫暖、鼓勵的言語點亮山谷的夜空。</span>
@@ -60,6 +61,7 @@ export default function CommentForm() {
             <span className="text-lg font-semibold mb-2">回聲</span>
             <textarea
               name="content"
+              data-testid="content"
               className="border border-gray-300 rounded-md p-2"
               rows={4}
               placeholder="在這裏留下你的回聲..."
@@ -76,7 +78,7 @@ export default function CommentForm() {
             </Button>
             。
           </p>
-          <Button type="submit" className="w-full mt-4 cursor-pointer" disabled={isPending}>
+          <Button type="submit" data-testid="submit-button" className="w-full mt-4 cursor-pointer" disabled={isPending}>
             {isPending ? '請稍後...' : '發送'}
           </Button>
           {(state.error) ? <div className="text-red-500 mt-2">發送失敗，請稍後再試。</div> : null}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -35,8 +35,8 @@ export default function Footer(props: React.HTMLProps<HTMLDivElement>) {
         <ul className="overflow-clip ps-2 my-2 space-y-4">
           <li>
             <div className="flex flex-col md:flex-row justify-start space-x-0 md:space-x-4 space-y-2 md:space-y-0 text-sm">
-              <Link href="/privacy" className="underline-offset-2 hover:underline">私隱聲明</Link>
-              <Link href="/about" className="underline-offset-2 hover:underline">關於「山谷」</Link>
+              <Link href="/privacy" data-testid="privacy" className="underline-offset-2 hover:underline">私隱聲明</Link>
+              <Link href="/about" data-testid="about" className="underline-offset-2 hover:underline">關於「山谷」</Link>
             </div>
           </li>
           <li>

--- a/tests/fixtures/cls/database.ts
+++ b/tests/fixtures/cls/database.ts
@@ -1,0 +1,61 @@
+import { neon, NeonQueryFunction } from "@neondatabase/serverless";
+import Item from "@/interfaces/item";
+
+import dotenv from "dotenv";
+import path from "path";
+dotenv.config({ path: path.resolve(__dirname, "..", "..", "..", ".env.local") });
+
+export default class Database{
+  sql: NeonQueryFunction<false, false>;
+  constructor() {
+    this.sql = neon(`${process.env.DATABASE_URL_DEV}`);
+  }
+
+  async checkLatestPending(table: "silent" | "starlight") {
+    let result: Record<string, Item>[];
+    switch (table) {
+      case "silent":
+        result = await this.sql`SELECT id, name, content, created_at FROM silent_comments WHERE status='pending' ORDER BY created_at DESC LIMIT 1;`;
+        break;
+      case "starlight":
+        result = await this.sql`SELECT id, name, content, created_at FROM starlight_comments WHERE status='pending' ORDER BY created_at DESC LIMIT 1;`;
+        break;
+    }
+    return result;
+  }
+
+  async checkByName(name: string, table: "silent" | "starlight") {
+    let result: Record<string, Item>[];
+    switch (table) {
+      case "silent":
+        result = await this.sql`SELECT id, name, content, status FROM silent_comments WHERE name=${name} ORDER BY created_at DESC LIMIT 1;`;
+        break;
+      case "starlight":
+        result = await this.sql`SELECT id, name, content, status FROM starlight_comments WHERE name=${name} ORDER BY created_at DESC LIMIT 1;`;
+        break;
+    }
+    return result;
+  }
+
+  async insertAndApprove(name: string, content: string, table: "silent" | "starlight") {
+    switch (table) {
+      case "silent":
+        await this.sql`INSERT INTO silent_comments (name, content, status) VALUES (${name}, ${content}, 'approved');`;
+        break;
+      case "starlight":
+        await this.sql`INSERT INTO starlight_comments (name, content, status) VALUES (${name}, ${content}, 'approved');`;
+        break;
+    }
+  }
+
+  async cleanupByName(name: string, table: "silent" | "starlight") {
+    switch (table) {
+      case "silent":
+        await this.sql`DELETE FROM silent_comments WHERE name=${name};`;
+        break;
+      case "starlight":
+        await this.sql`DELETE FROM starlight_comments WHERE name=${name};`;
+        break;
+    }
+  }
+}

--- a/tests/fixtures/test_db.ts
+++ b/tests/fixtures/test_db.ts
@@ -1,0 +1,16 @@
+import { test } from '@playwright/test';
+
+import database from './cls/database';
+
+type dbFixture = {
+  db: database;
+}
+
+const extendedTest = test.extend<dbFixture>({
+  db: async ({}, testUse) => {
+    const db = new database();
+    await testUse(db);
+  }
+});
+
+export default extendedTest;

--- a/tests/functionality.spec.ts
+++ b/tests/functionality.spec.ts
@@ -24,7 +24,9 @@ testwithdb('Can create echo to silent echoes', async ({ page, db }) => {
   await page.getByTestId('submit-button').click();
   
   /* Wait until the request is sent */
-  await page.waitForTimeout(1000);
+  await page.waitForResponse((response) => {
+    return response.url().includes('/create') && response.status() === 200;
+  });
 
   /* Check if the latest pending echo in the database matches the input */
   const result = await db.checkByName(echoData.name, 'silent');
@@ -59,7 +61,9 @@ testwithdb('Can create echo to starlight echoes', async ({ page, db }) => {
   await page.getByTestId('submit-button').click();
   
   /* Wait until the request is sent */
-  await page.waitForTimeout(1000);
+  await page.waitForResponse((response) => {
+    return response.url().includes('/create') && response.status() === 200;
+  });
 
   /* Check if the latest pending echo in the database matches the input */
   const result = await db.checkByName(echoData.name, 'starlight');

--- a/tests/functionality.spec.ts
+++ b/tests/functionality.spec.ts
@@ -1,0 +1,115 @@
+import testwithdb from './fixtures/test_db';
+import { expect } from '@playwright/test';
+
+testwithdb('Can create echo to silent echoes', async ({ page, db }) => {
+  /* Test data */
+  const echoData = {
+    name: `E2E Test ${Math.floor(Math.random() * 1000)}`,
+    content: `This is a test echo for silent echoes: ${Math.floor(Math.random() * 1000)}`,
+  };
+
+  /* Navigate to create page */
+  await page.goto(`${process.env.BASE_URL ?? ''}/create`);
+
+  /* Fill in name */
+  await page.getByTestId('name').fill(echoData.name);
+
+  /* Choose "silent" category */
+  await page.getByTestId('cat-silent').check();
+
+  /* Fill in content */
+  await page.getByTestId('content').fill(echoData.content);
+
+  /* Submit the form */
+  await page.getByTestId('submit-button').click();
+  
+  /* Wait until the request is sent */
+  await page.waitForTimeout(1000);
+
+  /* Check if the latest pending echo in the database matches the input */
+  const result = await db.checkByName(echoData.name, 'silent');
+  expect(result[0].name).toBe(echoData.name);
+  expect(result[0].content).toBe(echoData.content);
+  expect(result[0].status).toBe('pending');
+
+  /* Clean up the database */
+  await db.cleanupByName(echoData.name, 'silent');
+});
+
+testwithdb('Can create echo to starlight echoes', async ({ page, db }) => {
+  /* Test data */
+  const echoData = {
+    name: `E2E Test ${Math.floor(Math.random() * 1000)}`,
+    content: `This is a test echo for starlight echoes: ${Math.floor(Math.random() * 1000)}`,
+  };
+
+  /* Navigate to create page */
+  await page.goto(`${process.env.BASE_URL ?? ''}/create`);
+
+  /* Fill in name */
+  await page.getByTestId('name').fill(echoData.name);
+
+  /* Choose "starlight" category */
+  await page.getByTestId('cat-starlight').check();
+
+  /* Fill in content */
+  await page.getByTestId('content').fill(echoData.content);
+
+  /* Submit the form */
+  await page.getByTestId('submit-button').click();
+  
+  /* Wait until the request is sent */
+  await page.waitForTimeout(1000);
+
+  /* Check if the latest pending echo in the database matches the input */
+  const result = await db.checkByName(echoData.name, 'starlight');
+  expect(result[0].name).toBe(echoData.name);
+  expect(result[0].content).toBe(echoData.content);
+  expect(result[0].status).toBe('pending');
+  
+  /* Clean up the database */
+  await db.cleanupByName(echoData.name, 'starlight');
+});
+
+testwithdb('Can view new approved silent echoes', async ({ page, db }) => {
+  /* Test data */
+  const echoData = {
+    name: `E2E Test ${Math.floor(Math.random() * 1000)}`,
+    content: `This is a test echo for silent echoes: ${Math.floor(Math.random() * 1000)}`,
+  };
+
+  /* Insert and approve the echo in the database */
+  await db.insertAndApprove(echoData.name, echoData.content, 'silent');
+
+  /* Navigate to silent echoes page */
+  await page.goto(`${process.env.BASE_URL ?? ''}/viewsilent`);
+
+  /* Check if the echo is displayed */
+  const echoElement = await page.getByText(echoData.content);
+  expect(echoElement).toBeTruthy();
+
+  /* Clean up the database */
+  await db.cleanupByName(echoData.name, 'silent');
+});
+
+testwithdb('Can view new approved starlight echoes', async ({ page, db }) => {
+  /* Test data */
+  const echoData = {
+    name: `E2E Test ${Math.floor(Math.random() * 1000)}`,
+    content: `This is a test echo for starlight echoes: ${Math.floor(Math.random() * 1000)}`,
+  };
+
+  /* Insert and approve the echo in the database */
+  await db.insertAndApprove(echoData.name, echoData.content, 'starlight');
+
+  /* Navigate to starlight echoes page */
+  await page.goto(`${process.env.BASE_URL ?? ''}/viewstarlight`);
+
+  /* Check if the echo is displayed */
+  const echoElement = await page.getByText(echoData.content);
+  expect(echoElement).toBeTruthy();
+
+  /* Clean up the database */
+  await db.cleanupByName(echoData.name, 'starlight');
+});
+

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -23,3 +23,19 @@ test('Can navigate to "starlight echoes" page', async ({ page }) => {
 
   await expect(page).toHaveURL(/viewstarlight/);
 });
+
+test('Can navigate to "about" page', async ({ page }) => {
+  await page.goto(`${process.env.BASE_URL ?? ''}/`);
+
+  await page.getByTestId('about').click();
+
+  await expect(page).toHaveURL(/about/);
+});
+
+test('Can navigate to "privacy" page', async ({ page }) => {
+  await page.goto(`${process.env.BASE_URL ?? ''}/`);
+
+  await page.getByTestId('privacy').click();
+
+  await expect(page).toHaveURL(/privacy/);
+});


### PR DESCRIPTION
This PR populates functionality tests, and installs a dev-dependency `dotenv` for loading env during testing to create fixtures.

In short it tests for these items:
Navigation:
- Able to navigate to "about"
- Able to navigate to "pricvacy"
Functionality:
- Able to create echoes to database (both silent and starlight)
- Able to view newly approved echoes (both silent and starlight)