### PR TITLE
ux: add loading skeleton

### DIFF
--- a/src/app/viewsilent/[id]/page.tsx
+++ b/src/app/viewsilent/[id]/page.tsx
@@ -1,6 +1,15 @@
 "use server";
 
 import ViewCards from "@/components/ViewCards";
+import ViewCardsReplyForm from "@/components/ViewCards/ViewCardsReplyForm";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
+
+import Link from "next/link";
 
 export default async function Page(params: { params: Promise<{ id: string }> }) {
   const { id } = await params.params;
@@ -12,7 +21,29 @@ export default async function Page(params: { params: Promise<{ id: string }> }) 
         <h1 className="text-4xl font-bold mt-16 mb-8">谷聲回響</h1>
         <p className="text-lg mb-8">讓彼此的回聲在此共鳴。</p>
         <div className="my-8 w-full md:w-3/4">
-          <ViewCards cardType="silent" id={parseInt(id, 10)} isReply/>
+          <Button variant="outline" asChild>
+            <Link href="/viewsilent">
+              <span className="text-md">
+                <FontAwesomeIcon icon={faArrowLeft} />&nbsp;返回靜默之聲
+              </span>
+            </Link>
+          </Button>
+          <Card className="my-16">
+            <CardHeader>
+              <CardTitle className="text-2xl font-bold mb-2">
+                須知事項
+              </CardTitle>
+              <CardDescription className="text-md">
+                <ol className="list-decimal list-inside space-y-4">
+                  <li>禁止引用或轉載此處之內容，讓回聲僅在山谷中迴盪。</li>
+                  <li>旅人無需全盤接受此處之建議或鼓勵；感受由你定義。</li>
+                  <li>如感不適，請隨時離開此地。山谷隨時靜候你的回歸。</li>
+                </ol>
+              </CardDescription>
+            </CardHeader>
+          </Card>
+          <ViewCards cardType="silent" id={parseInt(id, 10)} isReply />
+          <ViewCardsReplyForm cardType="starlight" cardId={parseInt(id, 10)} className="my-4" />
         </div>
       </div>
     </div>

--- a/src/app/viewstarlight/[id]/page.tsx
+++ b/src/app/viewstarlight/[id]/page.tsx
@@ -2,6 +2,15 @@
 
 import ViewCards from "@/components/ViewCards";
 
+import ViewCardsReplyForm from "@/components/ViewCards/ViewCardsReplyForm";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
+
+import Link from "next/link";
+
 export default async function Page(params: { params: Promise<{ id: string }> }) {
   const { id } = await params.params;
   // const data = await res.json();
@@ -12,7 +21,29 @@ export default async function Page(params: { params: Promise<{ id: string }> }) 
         <h1 className="text-4xl font-bold mt-16 mb-8">谷聲回響</h1>
         <p className="text-lg mb-8">讓彼此的回聲在此共鳴。</p>
         <div className="my-8 w-full md:w-3/4">
-          <ViewCards cardType="starlight" id={parseInt(id, 10)} isReply/>
+          <Button variant="outline" asChild>
+            <Link href="/viewsilent">
+              <span className="text-md">
+                <FontAwesomeIcon icon={faArrowLeft} />&nbsp;返回星光之聲
+              </span>
+            </Link>
+          </Button>
+          <Card className="my-16">
+            <CardHeader>
+              <CardTitle className="text-2xl font-bold mb-2">
+                須知事項
+              </CardTitle>
+              <CardDescription className="text-md">
+                <ol className="list-decimal list-inside space-y-4">
+                  <li>禁止引用或轉載此處之內容，讓回聲僅在山谷中迴盪。</li>
+                  <li>旅人無需全盤接受此處之建議或鼓勵；感受由你定義。</li>
+                  <li>如感不適，請隨時離開此地。山谷隨時靜候你的回歸。</li>
+                </ol>
+              </CardDescription>
+            </CardHeader>
+          </Card>
+          <ViewCards cardType="starlight" id={parseInt(id, 10)} isReply />
+          <ViewCardsReplyForm cardType="starlight" cardId={parseInt(id, 10)} className="my-4" />
         </div>
       </div>
     </div>

--- a/src/components/ViewCards/ViewCardsReplyForm/index.tsx
+++ b/src/components/ViewCards/ViewCardsReplyForm/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 
 import { Button } from "@/components/ui/button";
@@ -98,7 +100,7 @@ export default function ViewCardsReplyForm({cardType, cardId, className}: ViewCa
           <hr className="my-4" />
           <Card className="my-4">
             <CardHeader>
-              <CardTitle className="text-2xl font-bold mb-4">發表共鳴成功！</CardTitle>
+              <CardTitle className="text-2xl font-bold text-green-500 mb-4">發表共鳴成功！</CardTitle>
               <CardDescription className="text-md">
                 <p>
                   感謝你的回覆！我們會在審核後將其發佈到山谷中，讓更多的旅人能夠看到。

--- a/src/components/ViewCards/index.tsx
+++ b/src/components/ViewCards/index.tsx
@@ -21,16 +21,17 @@ import {
 
 import ViewCard from "@/components/ViewCards/ViewCard";
 
+import { Skeleton } from "@/components/ui/skeleton";
+
 import { Item } from "@/interfaces/item";
 
 type ViewCardsProps = {
   cardType: "silent" | "starlight";
   isReply?: boolean;
   id: number;
-  className?: string;
 }
 
-export default function ViewCards({cardType, id, isReply, className}: ViewCardsProps) {
+export default function ViewCards({cardType, id, isReply}: ViewCardsProps) {
   if (id === 0 && isReply) {
     throw new Error("If the cards are shown in a page for replies, id must be provided.");
   }
@@ -65,14 +66,10 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
     return (
       <>
         {/* Loading */}
-        <Card className={className}>
-          <CardHeader>
-            <CardTitle className="text-2xl font-bold mb-2">加載中</CardTitle>
-            <CardDescription className="text-md">
-              <div>靜靜地等待回聲的到來...</div>
-            </CardDescription>
-          </CardHeader>
-        </Card>
+        <div>
+          <Skeleton className="h-48 w-full bg-card rounded-xl my-4" />
+          <Skeleton className="h-48 w-full bg-card rounded-xl my-4" />
+        </div>
       </>
     );
   }
@@ -81,7 +78,7 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
     return (
       <>
         {/* Error handling*/}
-        <Card className={className}>
+        <Card>
           <CardHeader>
             <CardTitle className="text-2xl font-bold mb-2 text-red-500">
               哎呀！發生了錯誤
@@ -100,7 +97,7 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
     return (
       <>
         {/* No data */}
-        <Card className={className}>
+        <Card>
           <CardHeader>
             <CardTitle className="text-2xl font-bold mb-2">好靜啊...</CardTitle>
             <CardDescription className="text-md">
@@ -116,6 +113,7 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
     <>
       <div aria-hidden="true" id="top" />
       {/* Normal */}
+      
       {/* This is to show the original card in viewing replies*/
         isReply ? ( 
           <>
@@ -125,6 +123,7 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
           </>
         ) : null
       }
+
       {data.map((item: Item, index: number) => (
         <ViewCard key={index} datum={item} cardType={cardType} className="my-4" isReply={isReply}/>
       ))}
@@ -143,7 +142,7 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
             />
           </PaginationItem>
           <PaginationItem>
-            <PaginationLink>{currentPage}</PaginationLink>
+            <PaginationLink href="#top">{currentPage}</PaginationLink>
           </PaginationItem>
           <PaginationItem>
             <PaginationNext 

--- a/src/components/ViewCards/index.tsx
+++ b/src/components/ViewCards/index.tsx
@@ -20,14 +20,8 @@ import {
 } from "@/components/ui/pagination";
 
 import ViewCard from "@/components/ViewCards/ViewCard";
-import ViewCardsReplyForm from "./ViewCardsReplyForm";
 
 import { Item } from "@/interfaces/item";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
-
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 
 type ViewCardsProps = {
   cardType: "silent" | "starlight";
@@ -125,27 +119,6 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
       {/* This is to show the original card in viewing replies*/
         isReply ? ( 
           <>
-            <Button variant="outline" asChild>
-              <Link href={cardType === "silent" ? "/viewsilent" : "/viewstarlight"}>
-                <span className="text-md">
-                  <FontAwesomeIcon icon={faArrowLeft} />&nbsp;返回{cardType === "silent" ? "靜默" : "星光"}之聲
-                </span>
-              </Link>
-            </Button>
-            <Card className="my-16">
-              <CardHeader>
-                <CardTitle className="text-2xl font-bold mb-2">
-                  須知事項
-                </CardTitle>
-                <CardDescription className="text-md">
-                  <ol className="list-decimal list-inside space-y-4">
-                    <li>禁止引用或轉載此處之內容，讓回聲僅在山谷中迴盪。</li>
-                    <li>旅人無需全盤接受此處之建議或鼓勵；感受由你定義。</li>
-                    <li>如感不適，請隨時離開此地。山谷隨時靜候你的回歸。</li>
-                  </ol>
-                </CardDescription>
-              </CardHeader>
-            </Card>
             {op ? <ViewCard datum={op} cardType={cardType} className="my-4" isReply={isReply}/> : null}
             <hr className="my-4" />
             <h2 className="text-2xl font-bold my-4">共鳴</h2>
@@ -184,9 +157,6 @@ export default function ViewCards({cardType, id, isReply, className}: ViewCardsP
           </PaginationItem>
         </PaginationContent>
       </Pagination>
-      {isReply ? (
-        <ViewCardsReplyForm cardType={cardType} cardId={id} className={`${isReply ? "block" : "hidden"} my-4`} />
-      ) : null}
     </>
   );
 }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
This PR did 2 things:
1. Moved a lot of code from `ViewCards` to their page, mainly things related to `isReply`.
2. Added skeleton for loading instead of text-based loading indicator.