### PR TITLE
fix: manually override to address CVE-2024-53382

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "the-vale",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
-        "@ai-sdk/azure": "^2.0.23",
-        "@ai-sdk/react": "^2.0.30",
+        "@ai-sdk/azure": "^2.0.27",
+        "@ai-sdk/react": "^2.0.38",
         "@clerk/localizations": "^3.24.1",
         "@clerk/nextjs": "^6.31.8",
         "@clerk/themes": "^2.4.16",
@@ -35,7 +35,7 @@
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@react-spring/web": "^10.0.1",
         "@upstash/ratelimit": "^2.0.6",
-        "ai": "^5.0.30",
+        "ai": "^5.0.38",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "embla-carousel-react": "^8.6.0",
@@ -70,14 +70,14 @@
       }
     },
     "node_modules/@ai-sdk/azure": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-2.0.23.tgz",
-      "integrity": "sha512-+Epq/QF8B8E1xD+dT4LsJ6FF2rHPqSEbWDLjqnzuoj5nRXLK0LSFQIQ8/zNAl9Sg3xud4FT3KaUtbz595JKAVQ==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-2.0.27.tgz",
+      "integrity": "sha512-kVEkLQIIahzuBRPaUlHpZlOiVNr2Zp0cMKyjCpbb/agUt5x5OjtOEMOraHavd5i0PAvuZa4vYtTtI4rSP9ywcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/openai": "2.0.23",
+        "@ai-sdk/openai": "2.0.27",
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.7"
+        "@ai-sdk/provider-utils": "3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -87,13 +87,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.15.tgz",
-      "integrity": "sha512-xySXoQ29+KbGuGfmDnABx+O6vc7Gj7qugmj1kGpn0rW0rQNn6UKUuvscKMzWyv1Uv05GyC1vqHq8ZhEOLfXscQ==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.20.tgz",
+      "integrity": "sha512-2K0kGnHyLfT1v2+3xXbLqohfWBJ/vmIh1FTWnrvZfvuUuBdOi2DMgnSQzkLvFVLyM8mhOcx+ZwU6IOOsuyOv/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.7"
+        "@ai-sdk/provider-utils": "3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -103,13 +103,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.23.tgz",
-      "integrity": "sha512-uOXk8HzmMUoCmD0JMX/Y1HC/ABOR/Jza2Z2rkCaJISDYz3fp5pnb6eNjcPRL48JSMzRAGp9UP5p0OpxS06IJZg==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.27.tgz",
+      "integrity": "sha512-5fUFBlE9qGFgezVIVkzQk87qZYkxsn5PsedtCFPoGxHK6c2QVYHuD1UcrVIKt0elr043Vx17Xo/gS5oJAR5YEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.7"
+        "@ai-sdk/provider-utils": "3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.7.tgz",
-      "integrity": "sha512-o3BS5/t8KnBL3ubP8k3w77AByOypLm+pkIL/DCw0qKkhDbvhCy+L3hRTGPikpdb8WHcylAeKsjgwOxhj4cqTUA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.8.tgz",
+      "integrity": "sha512-cDj1iigu7MW2tgAQeBzOiLhjHOUM9vENsgh4oAVitek0d//WdgfPCsKO3euP7m7LyO/j9a1vr/So+BGNdpFXYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
@@ -148,13 +148,13 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.30.tgz",
-      "integrity": "sha512-3DepYWZqR4RgowpVYllsIWDCiYl3lHWN1w4fp+uLIvyqlWnTZqa3PWdEWjHbxNt98Y9Vh0VpVQKyAN7t3+to1Q==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.38.tgz",
+      "integrity": "sha512-B0peqEBNRwFv2FXSXaSiTyZGKJzRMMGK7E/OBtKbnvN7agX0V4AMbhhuAEYvloNb7fF7DnXEHUBXjehzIoDeMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "3.0.7",
-        "ai": "5.0.30",
+        "@ai-sdk/provider-utils": "3.0.8",
+        "ai": "5.0.38",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5438,14 +5438,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.30",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.30.tgz",
-      "integrity": "sha512-u7WdsDde9BasP+h8Q64CtU32GFShCYmxVtBa2h5dxM1f0w/AMKwzpmIDI1t3M3ean+L6uBiwOtRs8B2KA+OHgQ==",
+      "version": "5.0.38",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.38.tgz",
+      "integrity": "sha512-ocJURGbEXt1DNqurqavs43kBS2tTzWR71nMTWB1UKDswvjrgOLnibLDF/z7SeRV4DGWt8Kc5LWRXfNlBKkht0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "1.0.15",
+        "@ai-sdk/gateway": "1.0.20",
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.7",
+        "@ai-sdk/provider-utils": "3.0.8",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ai-sdk/azure": "^2.0.23",
-    "@ai-sdk/react": "^2.0.30",
+    "@ai-sdk/azure": "^2.0.27",
+    "@ai-sdk/react": "^2.0.38",
     "@clerk/localizations": "^3.24.1",
     "@clerk/nextjs": "^6.31.8",
     "@clerk/themes": "^2.4.16",
@@ -36,7 +36,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@react-spring/web": "^10.0.1",
     "@upstash/ratelimit": "^2.0.6",
-    "ai": "^5.0.30",
+    "ai": "^5.0.38",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
@@ -68,5 +68,12 @@
     "eslint-config-next": "15.5.2",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "react-syntax-highlighter": {
+      "refractor": {
+        "prismjs": "^1.30.0"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR overrides `refractor`'s dependency to introduce `prismjs` 1.30.0 in order to address CVE-2024-53382.